### PR TITLE
Add DataTables file-size plugin (modified)

### DIFF
--- a/DataTables-addons/file-size.js
+++ b/DataTables-addons/file-size.js
@@ -1,0 +1,44 @@
+/**
+ * When dealing with computer file sizes, it is common to append a post fix
+ * such as B, KB, MB or GB to a string in order to easily denote the order of
+ * magnitude of the file size. This plug-in allows sorting to take these
+ * indicates of size into account.
+ *
+ * A counterpart type detection plug-in is also available.
+ *
+ *  @name File size
+ *  @summary Sort abbreviated file sizes correctly (8MB, 4KB, etc)
+ *  @author Allan Jardine - datatables.net
+ *
+ *  @example
+ *    $('#example').DataTable( {
+ *       columnDefs: [
+ *         { type: 'file-size', targets: 0 }
+ *       ]
+ *    } );
+ */
+
+jQuery.fn.dataTable.ext.type.order['file-size-pre'] = function ( data ) {
+    var matches = data.match( /^(\d+(?:\.\d+)?)\s*([a-z]+)/i );
+    var multipliers = {
+        b:  1,
+        bytes: 1,
+        kb: 1000,
+        kib: 1024,
+        mb: 1000000,
+        mib: 1048576,
+        gb: 1000000000,
+        gib: 1073741824,
+        tb: 1000000000000,
+        tib: 1099511627776,
+        pb: 1000000000000000,
+        pib: 1125899906842624
+    };
+
+    if (matches) {
+        var multiplier = multipliers[matches[2].toLowerCase()];
+        return parseFloat( matches[1] ) * multiplier;
+    } else {
+        return -1;
+    };
+};


### PR DESCRIPTION
Ref to #12 and rockstor/rockstor-core#1673

Added file-size DataTables plugin (modified version from my fork, already pushed to DataTables plugin repo)

Ready to be merged @schakrava 

NOTE to @schakrava and @priyaganti
Noticed we miss `jquery.dataTables.min.js` lib on rockstor-jslibs repo, while we have it on Rockstor downloaded js packages ?!?

Mirko