### PR TITLE
update license, with permission, on jquery-cron-window.js #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Foundation.
 
 As such this repository, overall, has the license identifier:
 
-`SPDX-License-Identifier: (MIT AND GPL-2.0-or-later AND Apache-2.0 AND GPL-2.0-only AND LGPL-3.0-or-later AND BSD-3-Clause AND ISC)`
+`SPDX-License-Identifier: (MIT AND GPL-2.0-or-later AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND BSD-3-Clause AND ISC)`
 
 All of which are both FSF Free/Libre, & OSI approved according to:
 [SPDX License List](https://spdx.org/licenses/)
@@ -42,7 +42,7 @@ This can lead to a discrepancy between website link license (latest) and the fil
 │        │       └── loading.gif  
 │        ├── jquery-cron.css  
 │        ├── jquery-cron.js           `SPDX-License-Identifier: (MIT or  GPL-2.0-or-later)` https://github.com/shawnchin/jquery-cron  
-│        └── jquery-cron-window.js    `SPDX-License-Identifier: GPL-2.0-only` https://github.com/rockstor/rockstor-jslibs/blob/master/cron/jquery-cron-window.js  
+│        └── jquery-cron-window.js    `SPDX-License-Identifier: GPL-3.0-or-later` https://github.com/rockstor/rockstor-jslibs/blob/master/cron/jquery-cron-window.js  
 ├── cubism.v1.js                      `SPDX-License-Identifier: Apache-2.0` https://github.com/square/cubism  
 ├── d3-tip.js                         `SPDX-License-Identifier: MIT` https://github.com/Caged/d3-tip  
 ├── d3.v3.min.js                      `SPDX-License-Identifier: ISC` https://github.com/d3/d3  

--- a/cron/jquery-cron-window.js
+++ b/cron/jquery-cron-window.js
@@ -4,7 +4,7 @@
  * http://shawnchin.github.com/jquery-cron
  *
  * Created by Mirko Arena for Rockstor BTRFS Storage System.
- * Licensed under the GPL Version 2 license.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  *
  * Requires:
  * - jQuery


### PR DESCRIPTION
Moved from "GPL Version 2 license" to:
"SPDX-License-Identifier: GPL-3.0-or-later"
Update repo README.md to reflect this change.

Fixes #22 
See linked issue for context.

Thanks to @MFlyer for allowing this licensing update.