### PR TITLE
Automate release creation post rockstor-core release #31

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude git config files from the generated tarball
+.git*   export-ignore
+
+# Exclude .github files
+.github/**  export-ignore

--- a/.github/workflows/update_release.yml
+++ b/.github/workflows/update_release.yml
@@ -1,0 +1,33 @@
+name: Create release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: version without release
+        type: string
+      target_branch:
+        required: true
+        description: branch to target when creating the release
+        type: string
+jobs:
+  create-release:
+    name: Create a release based on version received
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout jslibs
+        id: checkout-jslibs
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.target_branch }}
+      - name: Create release on rockstor/rockstor-jslibs
+        id: create-jslibs-release
+        run: |
+          gh release create ${{ inputs.version }} \
+          --notes "Tagging for next rockstor-core release." \
+          --title "${{ inputs.version }}" \
+          --target ${{ inputs.target_branch }}


### PR DESCRIPTION
Fixes #31 
This issue directly relates to https://github.com/rockstor/rockstor-core/issues/2596.

We currently manually create a new release of rockstor-jslibs every time a release in rockstor-core is made; as required by our rockstor-rpmbuild process.

This commit creates a GitHub Action workflow to automatically do that; this workflow is meant to be triggered by a parent workflow present in rockstor-core.

This commit also includes a .gitattributes file to exclude git and GitHub config files from the tarball of assets automatically created upon release creation.

@phillxnet: note that a `testing` branch would need to be created here post merging of this PR in order for it to be run on that branch as well.